### PR TITLE
Use ruby-platform for Nokogiri.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     domain_name (0.6.20240107)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
+    ffi (1.17.1)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
@@ -83,8 +84,12 @@ GEM
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
     method_source (1.1.0)
+    mini_portile2 (2.8.8)
     mutex_m (0.3.0)
     nenv (0.3.0)
+    nokogiri (1.18.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -169,6 +174,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Nokogiri is failing in airflow worker.

The failure is due to a missing library.  Using ruby as a platform fixes the issue.
